### PR TITLE
Serve favicon

### DIFF
--- a/Tracker/connection.cpp
+++ b/Tracker/connection.cpp
@@ -191,6 +191,16 @@ void Cconnection::read(const std::string& v)
  			s = srv_scrape(ti, find_user_by_torrent_pass(torrent_pass, ti.m_info_hash));
 		}
 		break;
+	case 'f':
+                if (v.size() >= 7)
+                {
+                        std::ifstream fin("favicon.ico", std::ios::in | std::ios::binary);
+                        std::ostringstream oss;
+                        oss << fin.rdbuf();
+                        h += "Content-Type: image/png\r\n";
+                        s = oss.str();
+                }
+                break;
 	}
 	if (s.empty())
 	{


### PR DESCRIPTION
A quick change for serving a favicon from the tracker. Maybe not the most efficient code (and I know headers aren't proper -- didn't bother to differentiate between favicon.ico and favicon.png requests), but hopefully this is useful for someone else.

Why? If someone is using redirect_url, there are many unneeded 302s without this change. Most GUI torrent clients now of days query for favicon at the base URL (eg http://tracker.example.com/favicon.png), instead of http://example.com/favicon.png. Additionally, many clients won't then try the favicon on the base domain after the 302, so any type of caching on their client for the favicon also fails.

So let's just serve the favicon from tracker, what could go wrong ;)