### PR TITLE
optimise slow queries

### DIFF
--- a/Tracker/tracker.cpp
+++ b/Tracker/tracker.cpp
@@ -175,7 +175,7 @@ void read_db_torrents()
 	{
 		if (!g_config.m_auto_register)
 		{
-			for (auto row : query(g_database, "select info_hash, @fid from @files where flags & 1"))
+			for (auto row : query(g_database, "select info_hash, @fid from @files where flags != 0 and flags & 1"))
 			{
 				g_torrents.erase(to_array<char, 20>(row[0]));
 				query("delete from @files where @fid = ?", row[1]);
@@ -329,7 +329,7 @@ void write_db_users()
 			"  mtime = values(mtime)", raw(g_torrents_users_updates_buffer));
 		g_torrents_users_updates_buffer.erase();
 	}
-	async_query("update @files_users set active = 0 where mtime < unix_timestamp() - 60 * 60");
+	async_query("update @files_users set active = 0 where active = 1 and mtime < unix_timestamp() - 60 * 60");
 	if (!g_users_updates_buffer.empty())
 	{
 		g_users_updates_buffer.pop_back();


### PR DESCRIPTION
The queries were slow
first one used full table scan, while it can take advantage of index on flags
second one scanned also those rows which were already active=0